### PR TITLE
Add commit message scope support

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ func main() {
 	var repoPath = flag.String("p", ".", "path to the repository, points to the current working directory by default")
 	var startCommit = flag.String("s", "", "commit hash string / revision (ex. HEAD, HEAD^, HEAD~2) \n to start collecting commit messages from")
 	var endCommit = flag.String("e", "", "commit hash string / revision (ex. HEAD, HEAD^, HEAD~2) \n to stop collecting commit message at")
-	var inclusionFlags = flag.String("i", "ci,refactor,docs,fix,feat,test,chore,other", "commit types to be includes")
+	var inclusionFlags = flag.String("i", clog.SupportedKeys, "commit types to be includes")
 	var skipClassification = flag.Bool("skip", false, "if true will skip trying to classify and just give a list of changes")
 
 	flag.Parse()


### PR DESCRIPTION
Add commit message scope support for all currently supported keys 

example commits 

```
chore(app): changed app boot status
feat(pwa): add support for chrome and firefox 
```

```markdown
# Chores
<commit-sha> - chore(app): changed app boot status

# Features
<commit-sha> - feat(pwa): add support for chrome and firefox 
```
