### PR TITLE
simplify tag check logic to revisions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Generate Change Log
         id: generate_log
         run: |
-          curl -sf https://gobinaries.com/barelyhuman/commitlog | sh
+          curl -sSL https://bina.egoist.sh/barelyhuman/commitlog | sh
           commitlog > CHANGELOG.md
       - uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   - pull_request
 
 jobs:
-  build:
+  build_and_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.13
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.16
 
       - name: Build
         run: go build -v ./...

--- a/cmd/commitlog/commitlog.go
+++ b/cmd/commitlog/commitlog.go
@@ -34,7 +34,9 @@ func Run(args []string) {
 		log.Fatalln(err)
 	}
 
-	changelog, clogErr := clog.CommitLog(*repoPath, *startCommit, *endCommit, *inclusionFlags, *skipClassification)
+	currentRepository := clog.OpenRepository(*repoPath)
+
+	changelog, clogErr := clog.CommitLog(currentRepository, *startCommit, *endCommit, *inclusionFlags, *skipClassification)
 
 	if clogErr.Err != nil {
 		log.Fatal(clogErr.Message, clogErr.Err)

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.13
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.8
 	github.com/fatih/color v1.12.0
+	github.com/go-git/go-billy/v5 v5.0.0 // indirect
 	github.com/go-git/go-git/v5 v5.2.0
 )

--- a/log/log.go
+++ b/log/log.go
@@ -134,8 +134,7 @@ func (container *logContainer) canAddToContainer(skip bool) bool {
 }
 
 // CommitLog - Generate commit log
-func CommitLog(path string, startCommitString string, endCommitString string, inclusionFlags string, skipClassification bool) (string, ErrMessage) {
-	currentRepository := OpenRepository(path)
+func CommitLog(currentRepository *git.Repository, startCommitString string, endCommitString string, inclusionFlags string, skipClassification bool) (string, ErrMessage) {
 	baseCommitReference, err := currentRepository.Head()
 	var startHash, endHash *object.Commit
 	var cIter object.CommitIter

--- a/log/log.go
+++ b/log/log.go
@@ -210,13 +210,14 @@ func CommitLog(currentRepository *git.Repository, startCommitString string, endC
 		key = strings.SplitN(strings.TrimSpace(key), ":", 2)[0]
 		normalizedHash := c.Hash.String() + " - " + normalizeCommit(c.Message, scopedKey)
 
-		logContainer.AddCommit(key, normalizedHash, skipClassification)
-
 		if endHash == nil && previousTag != nil && previousTag.Hash == c.Hash {
 			break
 		} else if endHash != nil && c.Hash == endHash.Hash {
 			break
 		}
+
+		logContainer.AddCommit(key, normalizedHash, skipClassification)
+
 	}
 	return logContainer.ToMarkdown(skipClassification), ErrMessage{}
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,124 @@
+package commitlog
+
+import (
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
+)
+
+var testCommits []string = []string{
+	"fix: fix commit",
+	"feat: feat commit",
+	"docs: doc update commit",
+	"chore: chore commit",
+	"other commit",
+}
+
+var expectedCommits []string
+
+func bail(err error) {
+	if err != nil {
+		log.Panic(err)
+	}
+}
+
+func setup(t *testing.T) *git.Repository {
+	var fs = memfs.New()
+	repo, _ := git.Init(memory.NewStorage(), fs)
+	wt, err := repo.Worktree()
+	bail(err)
+
+	for _, testCommitMsg := range testCommits {
+		commit, err := wt.Commit(testCommitMsg, &git.CommitOptions{
+			Author: &object.Signature{
+				Name:  "Reaper",
+				Email: "ahoy@barelyhuman.dev",
+				When:  time.Now(),
+			},
+		})
+		bail(err)
+		expectedCommits = append(expectedCommits, commit.String())
+	}
+
+	return repo
+}
+
+func TestCommitLogDefault(t *testing.T) {
+	repo := setup(t)
+
+	log, _ := CommitLog(repo, "", "", SupportedKeys, false)
+	if log == "" {
+		t.Fail()
+	}
+
+	for _, commit := range expectedCommits {
+		if !strings.Contains(log, commit) {
+			t.Fail()
+		}
+	}
+
+	t.Log(log)
+
+}
+
+func TestCommitLogSkipped(t *testing.T) {
+	repo := setup(t)
+
+	log, _ := CommitLog(repo, "", "", SupportedKeys, true)
+	if log == "" {
+		t.Fail()
+	}
+
+	for _, commit := range expectedCommits {
+		// Shouldn't contain classification headings
+		if strings.Contains(log, "##") {
+			t.Fail()
+		}
+
+		if !strings.Contains(log, commit) {
+			t.Fail()
+		}
+	}
+
+	t.Log(log)
+}
+
+func TestCommitLogInclusions(t *testing.T) {
+	repo := setup(t)
+
+	// include only feature commits
+	log, _ := CommitLog(repo, "", "", "feat", true)
+	if log == "" {
+		t.Fail()
+	}
+
+	ignoredHeadings := []string{
+		"## Fixes",
+		"## Performance",
+		"## CI",
+		"## Docs",
+		"## Chores",
+		"## Tests",
+		"## Other Changes",
+	}
+
+	for _, heading := range ignoredHeadings {
+		if strings.Contains(log, heading) {
+			t.Fail()
+		}
+	}
+
+	t.Log(log)
+}
+
+// TODO:
+// - Tests for checking between tags
+// - Variation of the above to check between 2 tags
+// - Another variation where one tag points to the head of the repo
+// - Test for checking start and end commit hashes passed as parameters

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -126,7 +126,6 @@ func TestCommitLogStartHash(t *testing.T) {
 	t.Log("Commits: ", expectedCommits)
 	t.Log("Start At:", startCommitHash)
 
-	// include only feature commits
 	log, _ := CommitLog(repo, startCommitHash, "", SupportedKeys, true)
 	if log == "" {
 		t.Fail()
@@ -151,12 +150,11 @@ func TestCommitLogEndHash(t *testing.T) {
 
 	endCommitHash := expectedCommits[1]
 	firstCommit := expectedCommits[0]
-	acceptedCommitHashes := expectedCommits[1:]
+	acceptedCommitHashes := expectedCommits[2:]
 
 	t.Log("Commits: ", expectedCommits)
 	t.Log("End At:", endCommitHash)
 
-	// include only feature commits
 	log, _ := CommitLog(repo, "", endCommitHash, SupportedKeys, true)
 	if log == "" {
 		t.Fail()
@@ -176,8 +174,3 @@ func TestCommitLogEndHash(t *testing.T) {
 
 	t.Log("\n", log)
 }
-
-// TODO:
-// - Tests for checking between tags
-// - Variation of the above to check between 2 tags
-// - Another variation where one tag points to the head of the repo

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -28,7 +28,7 @@ func bail(err error) {
 	}
 }
 
-func setup(t *testing.T) *git.Repository {
+func setup() *git.Repository {
 	var fs = memfs.New()
 	repo, _ := git.Init(memory.NewStorage(), fs)
 	wt, err := repo.Worktree()
@@ -49,8 +49,9 @@ func setup(t *testing.T) *git.Repository {
 	return repo
 }
 
+var repo *git.Repository = setup()
+
 func TestCommitLogDefault(t *testing.T) {
-	repo := setup(t)
 
 	log, _ := CommitLog(repo, "", "", SupportedKeys, false)
 	if log == "" {
@@ -68,7 +69,6 @@ func TestCommitLogDefault(t *testing.T) {
 }
 
 func TestCommitLogSkipped(t *testing.T) {
-	repo := setup(t)
 
 	log, _ := CommitLog(repo, "", "", SupportedKeys, true)
 	if log == "" {
@@ -90,7 +90,6 @@ func TestCommitLogSkipped(t *testing.T) {
 }
 
 func TestCommitLogInclusions(t *testing.T) {
-	repo := setup(t)
 
 	// include only feature commits
 	log, _ := CommitLog(repo, "", "", "feat", true)
@@ -117,8 +116,68 @@ func TestCommitLogInclusions(t *testing.T) {
 	t.Log(log)
 }
 
+func TestCommitLogStartHash(t *testing.T) {
+
+	expectedCommitsLen := len(expectedCommits)
+	startCommitHash := expectedCommits[expectedCommitsLen-2]
+	lastCommit := expectedCommits[expectedCommitsLen-1]
+	acceptedCommitHashes := expectedCommits[0 : expectedCommitsLen-1]
+
+	t.Log("Commits: ", expectedCommits)
+	t.Log("Start At:", startCommitHash)
+
+	// include only feature commits
+	log, _ := CommitLog(repo, startCommitHash, "", SupportedKeys, true)
+	if log == "" {
+		t.Fail()
+	}
+
+	// should have all commits except the last one
+	if strings.Contains(log, lastCommit) {
+		t.Fail()
+	}
+
+	for _, commitHash := range acceptedCommitHashes {
+		if !strings.Contains(log, commitHash) {
+			t.Log("Failed at:", commitHash)
+			t.Fail()
+		}
+	}
+
+	t.Log("\n", log)
+}
+
+func TestCommitLogEndHash(t *testing.T) {
+
+	endCommitHash := expectedCommits[1]
+	firstCommit := expectedCommits[0]
+	acceptedCommitHashes := expectedCommits[1:]
+
+	t.Log("Commits: ", expectedCommits)
+	t.Log("End At:", endCommitHash)
+
+	// include only feature commits
+	log, _ := CommitLog(repo, "", endCommitHash, SupportedKeys, true)
+	if log == "" {
+		t.Fail()
+	}
+
+	// should have all commits except the first one
+	if strings.Contains(log, firstCommit) {
+		t.Fail()
+	}
+
+	for _, commitHash := range acceptedCommitHashes {
+		if !strings.Contains(log, commitHash) {
+			t.Log("Failed at:", commitHash)
+			t.Fail()
+		}
+	}
+
+	t.Log("\n", log)
+}
+
 // TODO:
 // - Tests for checking between tags
 // - Variation of the above to check between 2 tags
 // - Another variation where one tag points to the head of the repo
-// - Test for checking start and end commit hashes passed as parameters

--- a/log/tag_test.go
+++ b/log/tag_test.go
@@ -1,0 +1,146 @@
+package commitlog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+func TestCommitLogSingleTag(t *testing.T) {
+	secondCommit := expectedCommits[1]
+	acceptedCommits := expectedCommits[2:]
+
+	t.Log("Commits:", expectedCommits)
+	t.Log("Tagged:", secondCommit)
+
+	hash, err := repo.ResolveRevision(plumbing.Revision(secondCommit))
+	bail(err)
+
+	_, err = repo.CreateTag("0.0.0", *hash, &git.CreateTagOptions{
+		Message: "0.0.0",
+	})
+	bail(err)
+
+	log, _ := CommitLog(repo, "", "", SupportedKeys, true)
+	if log == "" {
+		t.Fail()
+	}
+
+	if strings.Contains(log, expectedCommits[0]) {
+		t.Fail()
+	}
+
+	for _, commit := range acceptedCommits {
+		if !strings.Contains(log, commit) {
+			t.Fail()
+		}
+	}
+
+	t.Log(log)
+
+	// clean-up
+	bail(repo.DeleteTag("0.0.0"))
+
+}
+
+// Test with 2 tags, one on the second commit and one on the 2nd last commit,
+// should only have the last commit in the log
+func TestCommitLogDualTag(t *testing.T) {
+	secondCommit := expectedCommits[1]
+	secondLastCommit := expectedCommits[len(expectedCommits)-2]
+	acceptedCommit := expectedCommits[len(expectedCommits)-1]
+
+	t.Log("Commits:", expectedCommits)
+	t.Log("Tagged:", secondCommit, secondLastCommit)
+
+	secondHash, err := repo.ResolveRevision(plumbing.Revision(secondCommit))
+	bail(err)
+
+	secondLastHash, err := repo.ResolveRevision(plumbing.Revision(secondLastCommit))
+	bail(err)
+
+	_, err = repo.CreateTag("0.0.0", *secondHash, &git.CreateTagOptions{
+		Message: "0.0.0",
+	})
+	bail(err)
+
+	_, err = repo.CreateTag("0.0.1", *secondLastHash, &git.CreateTagOptions{
+		Message: "0.0.1",
+	})
+	bail(err)
+
+	log, _ := CommitLog(repo, "", "", SupportedKeys, true)
+	if log == "" {
+		t.Fail()
+	}
+
+	for _, commit := range expectedCommits {
+		if commit == acceptedCommit {
+			if !strings.Contains(log, acceptedCommit) {
+				t.Fail()
+			}
+		} else {
+			if strings.Contains(log, commit) {
+				t.Fail()
+			}
+		}
+
+	}
+
+	t.Log(log)
+
+	// clean-up
+	bail(repo.DeleteTag("0.0.0"))
+	bail(repo.DeleteTag("0.0.1"))
+}
+
+// Test with 2 tags, one on the second commit and one on the last commit,
+// should give all commits till the 1st tag
+func TestCommitLogHeadTag(t *testing.T) {
+	secondCommit := expectedCommits[1]
+	lastCommit := expectedCommits[len(expectedCommits)-1]
+
+	t.Log("Commits:", expectedCommits)
+	t.Log("Tagged:", secondCommit, lastCommit)
+
+	secondHash, err := repo.ResolveRevision(plumbing.Revision(secondCommit))
+	bail(err)
+
+	lastHash, err := repo.ResolveRevision(plumbing.Revision(lastCommit))
+	bail(err)
+
+	_, err = repo.CreateTag("0.0.0", *secondHash, &git.CreateTagOptions{
+		Message: "0.0.0",
+	})
+	bail(err)
+
+	_, err = repo.CreateTag("0.0.1", *lastHash, &git.CreateTagOptions{
+		Message: "0.0.1",
+	})
+	bail(err)
+
+	log, _ := CommitLog(repo, "", "", SupportedKeys, true)
+	if log == "" {
+		t.Fail()
+	}
+
+	for index, commit := range expectedCommits {
+		if index <= 1 {
+			if strings.Contains(log, commit) {
+				t.Fail()
+			}
+		}
+		if index > 1 && !strings.Contains(log, commit) {
+			t.Fail()
+		}
+
+	}
+
+	t.Log(log)
+
+	// clean-up
+	bail(repo.DeleteTag("0.0.0"))
+	bail(repo.DeleteTag("0.0.1"))
+}

--- a/log/tag_test.go
+++ b/log/tag_test.go
@@ -3,10 +3,24 @@ package commitlog
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
+
+func getTagOptions(message string) *git.CreateTagOptions {
+	return &git.CreateTagOptions{
+		Message: message,
+		Tagger: &object.Signature{
+			Name:  "Test",
+			Email: "test@reaper.im",
+			When:  time.Now(),
+		},
+	}
+
+}
 
 func TestCommitLogSingleTag(t *testing.T) {
 	secondCommit := expectedCommits[1]
@@ -18,9 +32,7 @@ func TestCommitLogSingleTag(t *testing.T) {
 	hash, err := repo.ResolveRevision(plumbing.Revision(secondCommit))
 	bail(err)
 
-	_, err = repo.CreateTag("0.0.0", *hash, &git.CreateTagOptions{
-		Message: "0.0.0",
-	})
+	_, err = repo.CreateTag("0.0.0", *hash, getTagOptions("0.0.0"))
 	bail(err)
 
 	log, _ := CommitLog(repo, "", "", SupportedKeys, true)
@@ -61,14 +73,10 @@ func TestCommitLogDualTag(t *testing.T) {
 	secondLastHash, err := repo.ResolveRevision(plumbing.Revision(secondLastCommit))
 	bail(err)
 
-	_, err = repo.CreateTag("0.0.0", *secondHash, &git.CreateTagOptions{
-		Message: "0.0.0",
-	})
+	_, err = repo.CreateTag("0.0.0", *secondHash, getTagOptions("0.0.0"))
 	bail(err)
 
-	_, err = repo.CreateTag("0.0.1", *secondLastHash, &git.CreateTagOptions{
-		Message: "0.0.1",
-	})
+	_, err = repo.CreateTag("0.0.1", *secondLastHash, getTagOptions("0.0.1"))
 	bail(err)
 
 	log, _ := CommitLog(repo, "", "", SupportedKeys, true)
@@ -111,14 +119,10 @@ func TestCommitLogHeadTag(t *testing.T) {
 	lastHash, err := repo.ResolveRevision(plumbing.Revision(lastCommit))
 	bail(err)
 
-	_, err = repo.CreateTag("0.0.0", *secondHash, &git.CreateTagOptions{
-		Message: "0.0.0",
-	})
+	_, err = repo.CreateTag("0.0.0", *secondHash, getTagOptions("0.0.0"))
 	bail(err)
 
-	_, err = repo.CreateTag("0.0.1", *lastHash, &git.CreateTagOptions{
-		Message: "0.0.1",
-	})
+	_, err = repo.CreateTag("0.0.1", *lastHash, getTagOptions("0.0.1"))
 	bail(err)
 
 	log, _ := CommitLog(repo, "", "", SupportedKeys, true)


### PR DESCRIPTION
checks commits on the initial iterations
to get data regarding the latest and previous tags and based on that
list out the changelog , also
uses revisions to check for tags instead of going through the
nearestTag again and again